### PR TITLE
Remove text-indent: -42px hack

### DIFF
--- a/app/sass/_message.scss
+++ b/app/sass/_message.scss
@@ -139,7 +139,6 @@
         word-wrap: break-word;
         margin-top: 0px;
         white-space: pre-wrap;
-        text-indent: -42px;
         font-size: 14px;
         font-family: $monospace-font;
 

--- a/app/templates/MessageView.hbs
+++ b/app/templates/MessageView.hbs
@@ -19,8 +19,7 @@
   </div>
   <div class="message-block">
     <pre class="message">
-      {{ztext message}}
-    </pre>
+{{ztext message}}</pre>
     <div class="bottom-row">
       <div class="signature">
         {{ztext signature}}


### PR DESCRIPTION
Each message was having six spaces prepended to it because templates are whitespace-sensitive.  Aside from being dumb, this was confusing copy and paste.
