### PR TITLE
Update crypto-js dependency link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 app/bower_components
 app/scripts-src/config.js
 app/.htaccess
+package-lock.json

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "bootstrap": "3.0.3",
     "MutationObservers": "https://github.com/Polymer/MutationObservers.git#~0.0.20131025",
     "WeakMap": "https://github.com/Polymer/WeakMap.git#~0.0.20131025",
-    "cryptojs": "https://crypto-js.googlecode.com/files/CryptoJS%20v3.1.2.zip",
+    "cryptojs": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/crypto-js/CryptoJS%20v3.1.2.zip",
     "jquery": "2.1.0"
   }
 }


### PR DESCRIPTION
The Google Code link no longer exists, so point to the Google Code archive instead. It's probably better to take this from the Github release instead, but this at least makes building work with as few changes as possible.